### PR TITLE
Assicura che `mvnw` abbia i caratteri LF anche su windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/mvnw text eol=lf


### PR DESCRIPTION
Questo forza `git` a fare il checkout di `mvnw` con i caratteri LF in tutte le piattaforme, anche quelle dove sono `CRLF` di default (es: windows)

Se avete già una copia locale della repo potrebbe essere necessario dare i comandi:
```
git rm --cached -r .
git reset --hard HEAD
```