### PR TITLE
Persistence - costruttori completi

### DIFF
--- a/Produlytics/persistence/src/main/java/it/deltax/produlytics/persistence/CharacteristicEntity.java
+++ b/Produlytics/persistence/src/main/java/it/deltax/produlytics/persistence/CharacteristicEntity.java
@@ -36,6 +36,26 @@ public class CharacteristicEntity {
 	protected CharacteristicEntity() {}
 
 	public CharacteristicEntity(
+		Integer id,
+		Integer deviceId,
+		String name,
+		Double upperLimit,
+		Double lowerLimit,
+		Boolean autoAdjust,
+		Integer sampleSize,
+		Boolean archived
+	) {
+		this.id = id;
+		this.deviceId = deviceId;
+		this.name = name;
+		this.upperLimit = upperLimit;
+		this.lowerLimit = lowerLimit;
+		this.autoAdjust = autoAdjust;
+		this.sampleSize = sampleSize;
+		this.archived = archived;
+	}
+
+	public CharacteristicEntity(
 		Integer deviceId,
 		String name,
 		Double upperLimit,

--- a/Produlytics/persistence/src/main/java/it/deltax/produlytics/persistence/DeviceEntity.java
+++ b/Produlytics/persistence/src/main/java/it/deltax/produlytics/persistence/DeviceEntity.java
@@ -24,6 +24,14 @@ public class DeviceEntity {
 
 	protected DeviceEntity() {}
 
+	public DeviceEntity(Integer id, String name, Boolean archived, Boolean deactivated, String apiKey) {
+		this.id = id;
+		this.name = name;
+		this.archived = archived;
+		this.deactivated = deactivated;
+		this.apiKey = apiKey;
+	}
+
 	public DeviceEntity(String name, Boolean archived, Boolean deactivated, String apiKey) {
 		this.name = name;
 		this.archived = archived;


### PR DESCRIPTION
Servono i costruttori completi per caratteristiche e macchine, per fare gli update con JPA come abbiamo fatto per le altre entities