### PR TITLE
Fix vari

### DIFF
--- a/Produlytics/api-rilevazioni/Dockerfile
+++ b/Produlytics/api-rilevazioni/Dockerfile
@@ -1,24 +1,23 @@
 FROM maven:3.8.4-openjdk-17 as persistence
 
-WORKDIR /persistence
-COPY persistence/pom.xml .
+WORKDIR /persistence/
+COPY persistence/pom.xml ./
 RUN mvn dependency:resolve-plugins dependency:go-offline
 
-COPY persistence/src ./src
+COPY persistence/src/ ./src/
 RUN mvn package
 
 FROM maven:3.8.4-openjdk-17 as api
 
-WORKDIR /persistence
+WORKDIR /persistence/
 COPY --from=persistence /persistence/target/persistence.jar /persistence/pom.xml ./
 RUN mvn install:install-file -Dfile=persistence.jar -DpomFile=pom.xml
 
-WORKDIR /api-rilevazioni
-COPY api-rilevazioni/pom.xml .
+WORKDIR /api-rilevazioni/
+COPY api-rilevazioni/pom.xml ./
 RUN mvn dependency:resolve-plugins dependency:go-offline
 
-COPY api-rilevazioni/src ./src
+COPY api-rilevazioni/src/ ./src/
 RUN mvn package -Dmaven.test.skip
 
-# CMD ["./mvnw", "test"]
 CMD ["java", "-jar", "./target/api.jar"]

--- a/Produlytics/ui/Dockerfile
+++ b/Produlytics/ui/Dockerfile
@@ -5,43 +5,42 @@ FROM node:16 as node
 # Front-end
 FROM node as front-end
 
-WORKDIR /front-end
-COPY ui/front-end/package.json ui/front-end/package-lock.json .
+WORKDIR /front-end/
+COPY ui/front-end/package.json ui/front-end/package-lock.json ./
 RUN npm ci
 
-COPY ui/front-end/src src
-COPY ui/front-end/*.json ui/front-end/*.js .
-# RUN npm install
+COPY ui/front-end/src/ src/
+COPY ui/front-end/*.json ui/front-end/*.js ./
 RUN npm run build --prod
 
 # Persistence
 FROM maven as persistence
 
-WORKDIR /persistence
-COPY persistence/pom.xml .
+WORKDIR /persistence/
+COPY persistence/pom.xml ./
 RUN mvn dependency:resolve-plugins dependency:go-offline
 
-COPY persistence/src ./src
+COPY persistence/src/ ./src/
 RUN mvn package
 
 # Back-end
 FROM maven as back-end
 
-WORKDIR /persistence
+WORKDIR /persistence/
 COPY --from=persistence /persistence/target/persistence.jar /persistence/pom.xml ./
 RUN mvn install:install-file -Dfile=persistence.jar -DpomFile=pom.xml
 
-WORKDIR /back-end
-COPY ui/back-end/pom.xml .
+WORKDIR /back-end/
+COPY ui/back-end/pom.xml ./
 RUN mvn dependency:resolve-plugins dependency:go-offline
 
-COPY ui/back-end/src ./src
+COPY ui/back-end/src/ ./src/
 RUN mvn package -Dmaven.test.skip
 
 # Assemblaggio
 FROM java as runner
 
-WORKDIR /app
-COPY --from=front-end /front-end/dist/produlytics-frontend ./static
-COPY --from=back-end back-end/target/back-end-ui.jar .
+WORKDIR /app/
+COPY --from=front-end /front-end/dist/produlytics-frontend/ ./static/
+COPY --from=back-end back-end/target/back-end-ui.jar ./
 CMD ["java", "-jar", "back-end-ui.jar"]

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/adapters/ConvertCharacteristic.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/adapters/ConvertCharacteristic.java
@@ -27,7 +27,7 @@ public interface ConvertCharacteristic {
                 : OptionalDouble.empty())
         .withUpperLimit(
             characteristic.getUpperLimit() != null
-                ? OptionalDouble.of(characteristic.getSampleSize())
+                ? OptionalDouble.of(characteristic.getUpperLimit())
                 : OptionalDouble.empty())
         .withAutoAdjust(characteristic.getAutoAdjust())
         .withSampleSize(

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/CharacteristicConstraints.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/CharacteristicConstraints.java
@@ -11,12 +11,9 @@ public interface CharacteristicConstraints {
    * @return true se e solo se le informazioni rispettano i vincoli
    */
   static boolean characteristicConstraintsOk(CharacteristicConstraintsToCheck toCheck) {
-    final boolean limitsOk =
-        toCheck.autoAdjust()
-            || (toCheck.upperLimit().isPresent() && toCheck.lowerLimit().isPresent());
+    final boolean autoAdjust = toCheck.autoAdjust();
+    final boolean technicalLimits = toCheck.upperLimit().isPresent() && toCheck.lowerLimit().isPresent();
 
-    final boolean sampleSizeOk = !toCheck.autoAdjust() || toCheck.sampleSize().isPresent();
-
-    return limitsOk && sampleSizeOk;
+    return autoAdjust || technicalLimits;
   }
 }

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/CharacteristicConstraints.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/CharacteristicConstraints.java
@@ -12,7 +12,8 @@ public interface CharacteristicConstraints {
    */
   static boolean characteristicConstraintsOk(CharacteristicConstraintsToCheck toCheck) {
     final boolean autoAdjust = toCheck.autoAdjust();
-    final boolean technicalLimits = toCheck.upperLimit().isPresent() && toCheck.lowerLimit().isPresent();
+    final boolean technicalLimits =
+        toCheck.upperLimit().isPresent() && toCheck.lowerLimit().isPresent();
 
     return autoAdjust || technicalLimits;
   }

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/InsertCharacteristicService.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/InsertCharacteristicService.java
@@ -54,11 +54,11 @@ public class InsertCharacteristicService implements InsertCharacteristicUseCase 
       throw new BusinessException("duplicateCharacteristicName", ErrorType.GENERIC);
     }
 
-//    if (characteristic.autoAdjust() && characteristic.sampleSize().isEmpty()) {
-//      characteristic = characteristic.toBuilder()
-//          .withSampleSize(OptionalInt.of(0))
-//          .build();
-//    }
+    if (characteristic.sampleSize().isPresent() && characteristic.sampleSize().getAsInt() == 0) {
+      characteristic = characteristic.toBuilder()
+          .withSampleSize(OptionalInt.empty())
+          .build();
+    }
 
     if (!CharacteristicConstraints.characteristicConstraintsOk(
         CharacteristicConstraintsToCheck.builder()

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/InsertCharacteristicService.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/InsertCharacteristicService.java
@@ -54,10 +54,8 @@ public class InsertCharacteristicService implements InsertCharacteristicUseCase 
       throw new BusinessException("duplicateCharacteristicName", ErrorType.GENERIC);
     }
 
-    if (characteristic.sampleSize().isPresent() && characteristic.sampleSize().getAsInt() == 0) {
-      characteristic = characteristic.toBuilder()
-          .withSampleSize(OptionalInt.empty())
-          .build();
+    if (characteristic.sampleSize().equals(OptionalInt.of(0))) {
+      characteristic = characteristic.toBuilder().withSampleSize(OptionalInt.empty()).build();
     }
 
     if (!CharacteristicConstraints.characteristicConstraintsOk(

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/InsertCharacteristicService.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/InsertCharacteristicService.java
@@ -54,11 +54,11 @@ public class InsertCharacteristicService implements InsertCharacteristicUseCase 
       throw new BusinessException("duplicateCharacteristicName", ErrorType.GENERIC);
     }
 
-    if (characteristic.autoAdjust() && characteristic.sampleSize().isEmpty()) {
-      characteristic = characteristic.toBuilder()
-          .withSampleSize(OptionalInt.of(0))
-          .build();
-    }
+//    if (characteristic.autoAdjust() && characteristic.sampleSize().isEmpty()) {
+//      characteristic = characteristic.toBuilder()
+//          .withSampleSize(OptionalInt.of(0))
+//          .build();
+//    }
 
     if (!CharacteristicConstraints.characteristicConstraintsOk(
         CharacteristicConstraintsToCheck.builder()

--- a/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/UpdateCharacteristicService.java
+++ b/Produlytics/ui/back-end/src/main/java/it/deltax/produlytics/uibackend/admins/devices/business/services/UpdateCharacteristicService.java
@@ -9,6 +9,7 @@ import it.deltax.produlytics.uibackend.admins.devices.business.ports.out.FindDet
 import it.deltax.produlytics.uibackend.admins.devices.business.ports.out.UpdateCharacteristicPort;
 import it.deltax.produlytics.uibackend.exceptions.BusinessException;
 import it.deltax.produlytics.uibackend.exceptions.ErrorType;
+import java.util.OptionalInt;
 
 /** Il service per la modifica di una caratteristica. */
 public class UpdateCharacteristicService implements UpdateCharacteristicUseCase {
@@ -47,6 +48,10 @@ public class UpdateCharacteristicService implements UpdateCharacteristicUseCase 
         .findByDeviceAndName(toUpdate.deviceId(), toUpdate.name())
         .isEmpty()) {
       throw new BusinessException("duplicateCharacteristicName", ErrorType.GENERIC);
+    }
+
+    if (toUpdate.sampleSize().equals(OptionalInt.of(0))) {
+      toUpdate = toUpdate.toBuilder().withSampleSize(OptionalInt.empty()).build();
     }
 
     if (!CharacteristicConstraints.characteristicConstraintsOk(

--- a/Produlytics/ui/back-end/src/test/java/it/deltax/produlytics/uibackend/integration/UpdateCharacteristicTests.java
+++ b/Produlytics/ui/back-end/src/test/java/it/deltax/produlytics/uibackend/integration/UpdateCharacteristicTests.java
@@ -51,7 +51,7 @@ public class UpdateCharacteristicTests {
 
     archivedCharacteristicId =
         this.characteristicRepository
-            .save(new CharacteristicEntity(deviceId, "pressione", 50d, -10d, false, 0, true))
+            .save(new CharacteristicEntity(deviceId, "pressione", 50d, -10d, false, null, true))
             .getId();
   }
 
@@ -220,20 +220,25 @@ public class UpdateCharacteristicTests {
    *     viene rilevato l'errore
    */
   @Test
-  void testUpdateCharacteristicNoSampleSizeError() throws Exception {
+  void testUpdateCharacteristicNoSampleSize() throws Exception {
     JSONObject body = new JSONObject().put("name", "frequenza").put("autoAdjust", true);
-
-    JSONObject response = new JSONObject().put("errorCode", "invalidValues");
 
     this.mockMvc
         .perform(
-            put("/admin/devices/" + deviceId + "/characteristics/" + characteristicId)
+            put("/admin/devices/" + deviceId + "/characteristics/" + archivedCharacteristicId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body.toString())
                 .characterEncoding("utf-8"))
         .andDo(print())
-        .andExpect(status().isBadRequest())
-        .andExpect(content().json(response.toString()));
+        .andExpect(status().isNoContent());
+
+    CharacteristicEntity characteristic =
+        this.characteristicRepository
+            .findById(new CharacteristicEntityId(deviceId, archivedCharacteristicId))
+            .get();
+
+    assertThat(characteristic.getName()).isEqualTo("frequenza");
+    assertThat(characteristic.getAutoAdjust()).isEqualTo(true);
   }
 
   /**

--- a/Produlytics/ui/back-end/src/test/java/it/deltax/produlytics/uibackend/unit/UpdateCharacteristicServiceTest.java
+++ b/Produlytics/ui/back-end/src/test/java/it/deltax/produlytics/uibackend/unit/UpdateCharacteristicServiceTest.java
@@ -110,24 +110,18 @@ public class UpdateCharacteristicServiceTest {
   }
 
   @Test
-  void testUpdateCharacteristicWithAutoAdjustAndNoSampleSize() {
+  void testUpdateCharacteristicWithAutoAdjustAndNoSampleSize() throws BusinessException {
     UpdateCharacteristicService service =
         new UpdateCharacteristicService(
             new FindDetailedCharacteristicPortMock(), new UpdateCharacteristicPortMock());
 
-    BusinessException exception =
-        assertThrows(
-            BusinessException.class,
-            () ->
-                service.updateCharacteristic(
-                    CharacteristicToUpdate.builder()
-                        .withId(1)
-                        .withDeviceId(1)
-                        .withName("pressione")
-                        .withAutoAdjust(true)
-                        .build()));
-    assert exception.getCode().equals("invalidValues");
-    assert exception.getType() == ErrorType.GENERIC;
+    service.updateCharacteristic(
+        CharacteristicToUpdate.builder()
+            .withId(1)
+            .withDeviceId(1)
+            .withName("pressione")
+            .withAutoAdjust(true)
+            .build());
   }
 
   @Test


### PR DESCRIPTION
- Fixa la query dei limiti quando sampleSize non è settato (invece che metterlo a 0)
- Fixa la query dei limiti quando l'utente imposta sampleSize a 0
- Fixa la query dei limiti quando non ci sono rilevazioni
- Fixa la query dei limiti del back-end quando ci sono più macchine
- Fixa i riferimenti alle cartelle nei `Dockerfile`